### PR TITLE
MWE for spacing fix

### DIFF
--- a/subfiles/title.tex
+++ b/subfiles/title.tex
@@ -45,15 +45,15 @@ healthcare technology, durable medical equipment, distributed ledger technology,
 \vspace*{1cm}
 \noindent
 \hfill
-\begin{minipage}{0.45\linewidth}
-    \begin{flushright}
-        \printauthor
-    \end{flushright}
-\end{minipage}
+%\begin{minipage}{0.45\linewidth}
+%    \begin{flushright}
+%        \printauthor
+%    \end{flushright}
+%\end{minipage}
 %
-\begin{minipage}{0.02\linewidth}
-    \rule{1.5pt}{80pt}
-\end{minipage}
+%\begin{minipage}{0.02\linewidth}
+%    \rule{1.5pt}{80pt}
+%\end{minipage}
 \end{titlepage}
 \clearpage
 \end{document}

--- a/whitepaper.tex
+++ b/whitepaper.tex
@@ -1,11 +1,12 @@
 
 \documentclass[10pt]{article}
  %wide margins
-\addtolength{\oddsidemargin}{-.75in}
-\addtolength{\evensidemargin}{-.75in}
-\addtolength{\textwidth}{1.5in}
-\addtolength{\topmargin}{-.875in}
-\addtolength{\textheight}{1.75in}
+%\addtolength{\oddsidemargin}{-.75in}
+%\addtolength{\evensidemargin}{-.75in}
+%\addtolength{\textwidth}{1.5in}
+%\addtolength{\topmargin}{-.875in}
+%\addtolength{\textheight}{1.75in}
+\usepackage[margins=1.25in]{geometry}
 
 % Invoke white paper style
 \input{CommitVersion.tex}


### PR DESCRIPTION
MWE demonstrating critical lines needed changes to address spacing error.

Changes cascade to `ehe.tex` as invoked in `architecture.tex` so as to result in new collisions with `tabu` items and increased margin.

As `LaTeX` is quite good at "typesetting itself," the `tabu` collision likely requires additional and/or modified parameters in that particular environment—aka not a global fix.

Please advise.